### PR TITLE
Add cpaste dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ centbot_pkgs:
   - python-beautifulsoup4
   - pytz
   - patch
+  - cpaste
 
 # httpd settings
 centbot_httpd_hostname: centbot.centos.org


### PR DESCRIPTION
cpaste is a requirement for the bots 'repasting' ability where it takes notices pastes for other paste services and re-pastes (where possible) to our pastebin and sends the resulting URL to the channel.  This PR adds the dependency.