### PR TITLE
Add cpaste dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ centbot_pkgs:
   - python-beautifulsoup4
   - pytz
   - patch
+  - cpaste
 
 # httpd settings
 centbot_httpd_hostname: centbot.centos.org


### PR DESCRIPTION
cpaste is required for the bot's repaste ability; this change adds the dep.